### PR TITLE
Exclude yml files from string processing

### DIFF
--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -7,3 +7,4 @@ github_org = $publish_org$
 dev_name = your name
 dev_github_handler = yourhandler_without_@
 dev_email = yourEmail
+verbatim = *.yml


### PR DESCRIPTION
Firstly, thanks very much for the useful template!

I've found that creating a new template with `sbt new typelevel/sbt-catalysts.g8` fails with the following error:

> Exiting due to error in the template: /tmp/giter8-32324943747504
> File: /tmp/giter8-32324943747504/src/main/g8/.travis.yml, 15:2: invalid character '-'

This could be because giter8 attempts to parse the strings in the .travis.yml file.  The file doesn't contain any string substitutions, so excluding it with the `verbatim` property resolves the problem.
